### PR TITLE
Add instructions for running component demos and tests locally

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,15 @@ Polymer Elements are built in the open, and the Polymer authors eagerly encourag
 
  3. **A list of browsers where the problem occurs.** This can be skipped if the problem is the same across all browsers.
 
+### Running component demos and tests locally
+
+You will need the [Polymer command-line interface](https://www.polymer-project.org/1.0/docs/tools/polymer-cli).
+
+ 1. Clone the desired PolymerElements component repo.
+ 2. Install the component's dependencies: `bower install`.
+ 3. To run the component's demo: `polymer serve --open`.
+ 4. To run the component's tests: `polymer test`.
+
 ### Submitting Pull Requests
 
 **Before creating a pull request**, please ensure that an issue exists for the corresponding change in the pull request that you intend to make. **If an issue does not exist, please create one per the guidelines above**. The goal is to discuss the design and necessity of the proposed change with Polymer authors and community before diving into a pull request.


### PR DESCRIPTION
This helps people coming directly to one of these repos, e.g., following a dependency mentioned in a bower.json or package.json to a repo, and who then want to run the component locally in a controlled environment.

I think it'd be even better to someday get these instructions — or a link to them — into the component ReadMe files. That way, a dev landing on the repo's top page will see how to get started. For the time being, putting these instructions in Contributing.md will at least get them into the individual component repos.
